### PR TITLE
metrics logging, timeouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -434,10 +434,10 @@ dict.o: dict.h honggfuzz.h libhfcommon/util.h libhfcommon/common.h
 dict.o: libhfcommon/log.h
 display.o: display.h honggfuzz.h libhfcommon/util.h libhfcommon/common.h
 display.o: libhfcommon/log.h
-fuzz.o: fuzz.h arch.h honggfuzz.h libhfcommon/util.h input.h
+fuzz.o: fuzz.h arch.h honggfuzz.h libhfcommon/util.h input.h hfuzz_metrics.h
 fuzz.o: libhfcommon/common.h libhfcommon/files.h libhfcommon/common.h
 fuzz.o: libhfcommon/log.h report.h sanitizers.h socketfuzzer.h subproc.h
-honggfuzz.o: cmdline.h honggfuzz.h libhfcommon/util.h dict.h display.h fuzz.h
+honggfuzz.o: cmdline.h honggfuzz.h libhfcommon/util.h dict.h display.h fuzz.h hfuzz_metrics.h
 honggfuzz.o: input.h libhfcommon/common.h libhfcommon/files.h
 honggfuzz.o: libhfcommon/common.h libhfcommon/log.h socketfuzzer.h subproc.h
 input.o: input.h honggfuzz.h libhfcommon/util.h dict.h fuzz.h
@@ -453,7 +453,7 @@ sanitizers.o: libhfcommon/common.h libhfcommon/log.h
 socketfuzzer.o: socketfuzzer.h honggfuzz.h libhfcommon/util.h
 socketfuzzer.o: libhfcommon/common.h libhfcommon/files.h libhfcommon/common.h
 socketfuzzer.o: libhfcommon/log.h libhfcommon/ns.h
-subproc.o: subproc.h honggfuzz.h libhfcommon/util.h arch.h fuzz.h
+subproc.o: subproc.h honggfuzz.h libhfcommon/util.h arch.h fuzz.h hfuzz_metrics.h
 subproc.o: libhfcommon/common.h libhfcommon/files.h libhfcommon/common.h
 subproc.o: libhfcommon/log.h
 hfuzz_cc/hfuzz-cc.o: honggfuzz.h libhfcommon/util.h libhfcommon/common.h
@@ -472,7 +472,7 @@ libhfnetdriver/netdriver.o: libhfcommon/files.h libhfcommon/common.h
 libhfnetdriver/netdriver.o: libhfcommon/log.h libhfcommon/ns.h
 libhfuzz/fetch.o: libhfuzz/fetch.h honggfuzz.h libhfcommon/util.h
 libhfuzz/fetch.o: libhfcommon/files.h libhfcommon/common.h libhfcommon/log.h
-libhfuzz/instrument.o: libhfuzz/instrument.h honggfuzz.h libhfcommon/util.h
+libhfuzz/instrument.o: libhfuzz/instrument.h honggfuzz.h libhfcommon/util.h hfuzz_metrics.h
 libhfuzz/instrument.o: libhfcommon/common.h libhfcommon/files.h
 libhfuzz/instrument.o: libhfcommon/common.h libhfcommon/log.h
 libhfuzz/linux.o: libhfcommon/common.h libhfcommon/files.h
@@ -499,7 +499,7 @@ linux/perf.o: libhfcommon/common.h libhfcommon/files.h libhfcommon/common.h
 linux/perf.o: libhfcommon/log.h linux/pt.h
 linux/pt.o: linux/pt.h honggfuzz.h libhfcommon/util.h libhfcommon/common.h
 linux/pt.o: libhfcommon/log.h
-linux/trace.o: linux/trace.h honggfuzz.h libhfcommon/util.h
+linux/trace.o: linux/trace.h honggfuzz.h libhfcommon/util.h hfuzz_metrics.h
 linux/trace.o: libhfcommon/common.h libhfcommon/files.h libhfcommon/common.h
 linux/trace.o: libhfcommon/log.h linux/bfd.h linux/unwind.h sanitizers.h
 linux/trace.o: report.h socketfuzzer.h subproc.h

--- a/Makefile
+++ b/Makefile
@@ -520,3 +520,4 @@ netbsd/unwind.o: libhfcommon/common.h libhfcommon/log.h
 posix/arch.o: arch.h honggfuzz.h libhfcommon/util.h fuzz.h
 posix/arch.o: libhfcommon/common.h libhfcommon/files.h libhfcommon/common.h
 posix/arch.o: libhfcommon/log.h report.h sanitizers.h subproc.h
+hfuzz_metrics.o: hfuzz_metrics.h libhfcommon/common.h

--- a/fuzz.c
+++ b/fuzz.c
@@ -339,6 +339,12 @@ static void fuzz_perfFeedback(run_t* run) {
             run->global->feedback.hwCnts.softCntEdge,
             run->global->feedback.hwCnts.softCntCmp,
             run->global->io.dynfileqCnt);
+        
+        /* Log detailed coverage map for source-level analysis */
+        uint64_t total_guards = atomic_load_explicit(&run->global->feedback.covFeedbackMap->guardNb, memory_order_relaxed);
+        hfuzz_metrics_log_detailed_coverage(
+            run->global->feedback.covFeedbackMap->pcGuardMap,
+            total_guards);
     } else if (run->dynfile->imported) {
         /* Remove useless imported inputs from corpus */
         LOG_D("Removing useless imported file: %s", run->dynfile->path);

--- a/fuzz.c
+++ b/fuzz.c
@@ -49,6 +49,7 @@
 #include "sanitizers.h"
 #include "socketfuzzer.h"
 #include "subproc.h"
+#include "hfuzz_metrics.h"
 
 static time_t termTimeStamp = 0;
 
@@ -328,6 +329,16 @@ static void fuzz_perfFeedback(run_t* run) {
             LOG_D("SocketFuzzer: fuzz: new BB (perf)");
             fuzz_notifySocketFuzzerNewCov(run->global);
         }
+
+        /* Log coverage metrics (optional - weak symbol, no-op if not overridden) */
+        hfuzz_metrics_log_coverage(
+            softNewPC,
+            softNewEdge,
+            softNewCmp,
+            run->global->feedback.hwCnts.softCntPc,
+            run->global->feedback.hwCnts.softCntEdge,
+            run->global->feedback.hwCnts.softCntCmp,
+            run->global->io.dynfileqCnt);
     } else if (run->dynfile->imported) {
         /* Remove useless imported inputs from corpus */
         LOG_D("Removing useless imported file: %s", run->dynfile->path);
@@ -501,6 +512,12 @@ static void fuzz_fuzzLoop(run_t* run) {
     }
     if (!subproc_Run(run)) {
         LOG_F("Couldn't run fuzzed command");
+    }
+
+    /* Log execution metrics (optional - weak symbol, no-op if not overridden) */
+    {
+        uint64_t exec_time_us = util_timeNowUSecs() - run->timeStartedUSecs;
+        hfuzz_metrics_log_execution(run->dynfile->size, exec_time_us);
     }
 
     if (run->global->feedback.dynFileMethod != _HF_DYNFILE_NONE) {

--- a/hfuzz_metrics.c
+++ b/hfuzz_metrics.c
@@ -1,0 +1,56 @@
+#include "hfuzz_metrics.h"
+
+#include "libhfcommon/common.h"
+
+/*
+ * All functions are marked weak so they can be overridden at link time.
+ * The default implementations are no-ops with zero overhead.
+ */
+
+__attribute__((weak)) 
+void hfuzz_metrics_session_init(const char* target_name HF_ATTR_UNUSED, 
+                                 int argc HF_ATTR_UNUSED, 
+                                 char** argv HF_ATTR_UNUSED) {
+    /* No-op by default */
+}
+
+__attribute__((weak)) 
+void hfuzz_metrics_session_end(const char* status HF_ATTR_UNUSED,
+                                uint64_t executions HF_ATTR_UNUSED,
+                                uint64_t crashes HF_ATTR_UNUSED,
+                                uint64_t hangs HF_ATTR_UNUSED,
+                                uint64_t cpu_seconds HF_ATTR_UNUSED,
+                                uint64_t memory_peak_mb HF_ATTR_UNUSED) {
+    /* No-op by default */
+}
+
+__attribute__((weak)) 
+void hfuzz_metrics_log_execution(size_t input_size HF_ATTR_UNUSED,
+                                  uint64_t exec_time_us HF_ATTR_UNUSED) {
+    /* No-op by default */
+}
+
+__attribute__((weak)) 
+void hfuzz_metrics_log_crash(const char* description HF_ATTR_UNUSED,
+                              uint64_t backtrace_hash HF_ATTR_UNUSED,
+                              size_t input_size HF_ATTR_UNUSED) {
+    /* No-op by default */
+}
+
+__attribute__((weak)) 
+void hfuzz_metrics_log_hang(size_t input_size HF_ATTR_UNUSED,
+                             uint64_t timeout_ms HF_ATTR_UNUSED) {
+    /* No-op by default */
+}
+
+__attribute__((weak)) 
+void hfuzz_metrics_log_coverage(uint64_t new_pcs HF_ATTR_UNUSED,
+                                 uint64_t new_edges HF_ATTR_UNUSED,
+                                 uint64_t new_cmp HF_ATTR_UNUSED,
+                                 uint64_t total_pcs HF_ATTR_UNUSED,
+                                 uint64_t total_edges HF_ATTR_UNUSED,
+                                 uint64_t total_cmp HF_ATTR_UNUSED,
+                                 size_t corpus_count HF_ATTR_UNUSED) {
+    /* No-op by default */
+}
+

--- a/hfuzz_metrics.c
+++ b/hfuzz_metrics.c
@@ -72,3 +72,18 @@ void hfuzz_metrics_register_module(const char* module_name HF_ATTR_UNUSED,
     /* No-op by default */
 }
 
+__attribute__((weak))
+void hfuzz_metrics_register_pc_table(const char* module_name HF_ATTR_UNUSED,
+                                      const hfuzz_pc_entry_t* pcs HF_ATTR_UNUSED,
+                                      size_t pc_count HF_ATTR_UNUSED,
+                                      uint32_t guard_start HF_ATTR_UNUSED) {
+    /* No-op by default */
+}
+
+__attribute__((weak))
+void hfuzz_metrics_log_full_coverage_report(const uint8_t* guard_map HF_ATTR_UNUSED,
+                                             uint64_t guard_count HF_ATTR_UNUSED,
+                                             const char* output_path HF_ATTR_UNUSED) {
+    /* No-op by default */
+}
+

--- a/hfuzz_metrics.c
+++ b/hfuzz_metrics.c
@@ -54,3 +54,21 @@ void hfuzz_metrics_log_coverage(uint64_t new_pcs HF_ATTR_UNUSED,
     /* No-op by default */
 }
 
+__attribute__((weak))
+void hfuzz_metrics_set_coverage_denominator(uint64_t total_guards HF_ATTR_UNUSED) {
+    /* No-op by default */
+}
+
+__attribute__((weak))
+void hfuzz_metrics_log_detailed_coverage(const uint8_t* guard_map HF_ATTR_UNUSED,
+                                          uint64_t guard_count HF_ATTR_UNUSED) {
+    /* No-op by default */
+}
+
+__attribute__((weak))
+void hfuzz_metrics_register_module(const char* module_name HF_ATTR_UNUSED,
+                                    uint32_t guard_start HF_ATTR_UNUSED,
+                                    uint32_t guard_count HF_ATTR_UNUSED) {
+    /* No-op by default */
+}
+

--- a/hfuzz_metrics.h
+++ b/hfuzz_metrics.h
@@ -119,6 +119,44 @@ void hfuzz_metrics_register_module(const char* module_name,
                                     uint32_t guard_start,
                                     uint32_t guard_count);
 
+/*
+ * PC table entry as provided by __sanitizer_cov_pcs_init.
+ * Each entry contains the PC address and flags (is_function_entry).
+ */
+typedef struct {
+    uintptr_t pc;
+    uintptr_t flags;  /* 1 = function entry, 0 = basic block */
+} hfuzz_pc_entry_t;
+
+/*
+ * Register PC table for a module (called from __sanitizer_cov_pcs_init).
+ * This provides the actual PC addresses that can be symbolized to source locations.
+ *
+ * module_name: path/name of the instrumented module  
+ * pcs: array of PC entries (address + flags pairs)
+ * pc_count: number of entries in the table
+ * guard_start: starting guard number for this module (to correlate with guard map)
+ *
+ * The PC table entries correspond 1:1 with guards, allowing us to map
+ * guard[i] -> pcs[i - guard_start] -> symbolized source location.
+ */
+void hfuzz_metrics_register_pc_table(const char* module_name,
+                                      const hfuzz_pc_entry_t* pcs,
+                                      size_t pc_count,
+                                      uint32_t guard_start);
+
+/*
+ * Log full coverage report with both covered and uncovered locations.
+ * Uses the registered PC tables to symbolize all guards.
+ *
+ * guard_map: pointer to the PC guard hit count map
+ * guard_count: number of guards in the map
+ * output_path: path to write JSON coverage report (NULL for ClickHouse only)
+ */
+void hfuzz_metrics_log_full_coverage_report(const uint8_t* guard_map,
+                                             uint64_t guard_count,
+                                             const char* output_path);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/hfuzz_metrics.h
+++ b/hfuzz_metrics.h
@@ -86,6 +86,39 @@ void hfuzz_metrics_log_coverage(uint64_t new_pcs,
                                  uint64_t total_cmp,
                                  size_t corpus_count);
 
+/*
+ * Set the coverage denominator (total possible coverage points).
+ * Called during initialization after PC guards are set up.
+ *
+ * total_guards: total number of PC guards instrumented
+ */
+void hfuzz_metrics_set_coverage_denominator(uint64_t total_guards);
+
+/*
+ * Log detailed coverage map for source-level analysis.
+ * Called periodically to enable file/function/line coverage tracking.
+ *
+ * guard_map: pointer to the PC guard hit count map
+ * guard_count: number of guards in the map
+ * 
+ * The implementation can iterate the map to count covered guards
+ * and use symbolization to map to source locations.
+ */
+void hfuzz_metrics_log_detailed_coverage(const uint8_t* guard_map, 
+                                          uint64_t guard_count);
+
+/*
+ * Notify metrics of a newly instrumented module for coverage tracking.
+ * Called from __sanitizer_cov_trace_pc_guard_init for each module.
+ *
+ * module_name: path/name of the instrumented module
+ * guard_start: starting guard number for this module
+ * guard_count: number of guards in this module
+ */
+void hfuzz_metrics_register_module(const char* module_name,
+                                    uint32_t guard_start,
+                                    uint32_t guard_count);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/hfuzz_metrics.h
+++ b/hfuzz_metrics.h
@@ -1,0 +1,94 @@
+#ifndef _HF_METRICS_H_
+#define _HF_METRICS_H_
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ * Initialize metrics session at fuzzer startup.
+ * Called from honggfuzz main() after threads are started.
+ *
+ * target_name: name of the fuzz target binary
+ * argc/argv: command line arguments
+ */
+void hfuzz_metrics_session_init(const char* target_name, int argc, char** argv);
+
+/*
+ * Finalize metrics session at fuzzer shutdown.
+ * Called from honggfuzz main() after mainThreadLoop() returns.
+ *
+ * status: "completed", "interrupted", or "crashed"
+ * executions: total number of executions
+ * crashes: total number of crashes detected
+ * hangs: total number of hangs/timeouts detected
+ * cpu_seconds: total CPU time used
+ * memory_peak_mb: peak memory usage in MB
+ */
+void hfuzz_metrics_session_end(const char* status, 
+                                uint64_t executions,
+                                uint64_t crashes, 
+                                uint64_t hangs,
+                                uint64_t cpu_seconds,
+                                uint64_t memory_peak_mb);
+
+/*
+ * Log a single execution completion.
+ * Called from fuzz_fuzzLoop() after each execution.
+ * Implementations should use time-based batching to avoid overhead.
+ *
+ * input_size: size of the input in bytes
+ * exec_time_us: execution time in microseconds
+ */
+void hfuzz_metrics_log_execution(size_t input_size, uint64_t exec_time_us);
+
+/*
+ * Log a crash detection.
+ * Called from linux/trace.c (or platform equivalent) after crashesCnt++.
+ *
+ * description: crash description string (signal, address, etc.)
+ * backtrace_hash: unique hash of the crash backtrace
+ * input_size: size of the crashing input
+ */
+void hfuzz_metrics_log_crash(const char* description, 
+                              uint64_t backtrace_hash,
+                              size_t input_size);
+
+/*
+ * Log a hang/timeout detection.
+ * Called from subproc.c after timeoutedCnt++.
+ *
+ * input_size: size of the hanging input
+ * timeout_ms: timeout threshold in milliseconds
+ */
+void hfuzz_metrics_log_hang(size_t input_size, uint64_t timeout_ms);
+
+/*
+ * Log coverage metrics update.
+ * Called from fuzz_perfFeedback() when coverage increases.
+ *
+ * new_pcs: new program counters discovered this execution
+ * new_edges: new edges discovered this execution
+ * new_cmp: new comparison progress this execution
+ * total_pcs: cumulative total PCs covered
+ * total_edges: cumulative total edges covered
+ * total_cmp: cumulative comparison progress
+ * corpus_count: number of inputs in the corpus
+ */
+void hfuzz_metrics_log_coverage(uint64_t new_pcs, 
+                                 uint64_t new_edges,
+                                 uint64_t new_cmp, 
+                                 uint64_t total_pcs,
+                                 uint64_t total_edges, 
+                                 uint64_t total_cmp,
+                                 size_t corpus_count);
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
+
+#endif /* _HF_METRICS_H_ */
+

--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -51,6 +51,7 @@
 #include "libhfcommon/util.h"
 #include "socketfuzzer.h"
 #include "subproc.h"
+#include "hfuzz_metrics.h"
 
 #if defined(_HF_ARCH_LINUX) && !defined(_HF_LINUX_NO_BFD)
 #include "linux/bfd.h"
@@ -509,6 +510,9 @@ int main(int argc, char** argv) {
     setupSignalsPreThreads();
     fuzz_threadsStart(&hfuzz);
 
+    /* Initialize metrics logging (optional - weak symbol, no-op if not overridden) */
+    hfuzz_metrics_session_init(hfuzz.exe.cmdline[0], argc, myargs);
+
     pthread_t sigthread;
     if (!subproc_runThread(&hfuzz, &sigthread, signalThread, /* joinable= */ false)) {
         LOG_F("Couldn't start the signal thread");
@@ -544,6 +548,28 @@ int main(int argc, char** argv) {
     }
 
     printSummary(&hfuzz);
+
+    /* Finalize metrics logging (optional - weak symbol, no-op if not overridden) */
+    {
+        uint64_t elapsed_sec = time(NULL) - hfuzz.timing.timeStart;
+        struct rusage usage;
+        uint64_t memory_peak_mb = 0;
+        if (getrusage(RUSAGE_CHILDREN, &usage) == 0) {
+#ifdef _HF_ARCH_DARWIN
+            memory_peak_mb = usage.ru_maxrss >> 20;
+#else
+            memory_peak_mb = usage.ru_maxrss >> 10;
+#endif
+        }
+        const char* status = (hfuzz.cfg.exitUponCrash && ATOMIC_GET(hfuzz.cnts.crashesCnt) > 0) 
+                             ? "crashed" : "completed";
+        hfuzz_metrics_session_end(status,
+                                   hfuzz.cnts.mutationsCnt,
+                                   hfuzz.cnts.crashesCnt,
+                                   hfuzz.cnts.timeoutedCnt,
+                                   elapsed_sec,
+                                   memory_peak_mb);
+    }
 
     return exitcode;
 }

--- a/honggfuzz.c
+++ b/honggfuzz.c
@@ -561,6 +561,24 @@ int main(int argc, char** argv) {
             memory_peak_mb = usage.ru_maxrss >> 10;
 #endif
         }
+        /* Log full coverage report before session end */
+        if (hfuzz.feedback.covFeedbackMap) {
+            uint64_t guardNb = atomic_load_explicit(
+                &hfuzz.feedback.covFeedbackMap->guardNb, memory_order_relaxed);
+            
+            /* Generate output path for JSON coverage report if coverage dir is set */
+            char coverage_path[PATH_MAX] = {0};
+            if (hfuzz.io.covDirNew) {
+                snprintf(coverage_path, sizeof(coverage_path), 
+                         "%s/coverage_report.json", hfuzz.io.covDirNew);
+            }
+            
+            hfuzz_metrics_log_full_coverage_report(
+                hfuzz.feedback.covFeedbackMap->pcGuardMap,
+                guardNb,
+                coverage_path[0] ? coverage_path : NULL);
+        }
+        
         const char* status = (hfuzz.cfg.exitUponCrash && ATOMIC_GET(hfuzz.cnts.crashesCnt) > 0) 
                              ? "crashed" : "completed";
         hfuzz_metrics_session_end(status,

--- a/libhfuzz/instrument.c
+++ b/libhfuzz/instrument.c
@@ -1206,9 +1206,50 @@ void __sanitizer_cov_8bit_counters_init(char* start, char* end) {
     }
 }
 
-/* Not implemented yet */
-void __sanitizer_cov_pcs_init(
-    const uintptr_t* pcs_beg HF_ATTR_UNUSED, const uintptr_t* pcs_end HF_ATTR_UNUSED) {
+/*
+ * Receive PC table from instrumentation.
+ * Each entry is a pair of (PC address, flags) where flags indicates function entry.
+ * This is called after __sanitizer_cov_trace_pc_guard_init for each module.
+ */
+void __sanitizer_cov_pcs_init(const uintptr_t* pcs_beg, const uintptr_t* pcs_end) {
+    if (pcs_beg >= pcs_end) {
+        return;
+    }
+    
+    /* Calculate number of PC entries (each entry is 2 uintptrs: PC + flags) */
+    size_t pc_count = (pcs_end - pcs_beg) / 2;
+    if (pc_count == 0) {
+        return;
+    }
+    
+    /* Get module name for this PC table */
+    Dl_info info;
+    const char* libName = "unknown";
+    if (dladdr((void*)pcs_beg, &info) && info.dli_fname) {
+        libName = info.dli_fname;
+    }
+    
+    /* Find the matching module registration to get the guard_start.
+     * The PC count should match the guard count for the module. */
+    uint32_t guard_start = 0;
+    uint64_t pathHash = util_hash(libName, strlen(libName));
+    
+    /* Search for a module with matching path hash and guard count */
+    uint32_t moduleCount = atomic_load_explicit(
+        &globalCovFeedback->trackedModuleCount, memory_order_acquire);
+    for (uint32_t i = 0; i < moduleCount && i < _HF_MAX_TRACKED_MODULES; i++) {
+        if (globalCovFeedback->trackedModules[i].pathHash == pathHash &&
+            globalCovFeedback->trackedModules[i].guardCount == (uint32_t)pc_count) {
+            guard_start = globalCovFeedback->trackedModules[i].baseGuard;
+            break;
+        }
+    }
+    
+    LOG_D("PC table init: %s with %zu PCs at guard_start=%u", libName, pc_count, guard_start);
+    
+    /* Notify metrics of the PC table (optional - weak symbol, no-op if not overridden) */
+    hfuzz_metrics_register_pc_table(libName, (const hfuzz_pc_entry_t*)pcs_beg, 
+                                     pc_count, guard_start);
 }
 
 unsigned instrumentThreadNo(void) {

--- a/libhfuzz/instrument.c
+++ b/libhfuzz/instrument.c
@@ -25,6 +25,7 @@
 #include "libhfcommon/files.h"
 #include "libhfcommon/log.h"
 #include "libhfcommon/util.h"
+#include "hfuzz_metrics.h"
 
 /* Cygwin doesn't support this */
 #if !defined(__CYGWIN__)
@@ -926,6 +927,9 @@ HF_REQUIRE_SSE42_POPCNT void __sanitizer_cov_trace_pc_guard_init(uint32_t* start
         
         LOG_I("PC-Guard module registration: %p-%p (count:%zu) at guard %u in slot %u", 
             start, stop, guardCount, baseGuard, slot);
+        
+        /* Notify metrics of new module (optional - weak symbol, no-op if not overridden) */
+        hfuzz_metrics_register_module(libName, baseGuard, (uint32_t)guardCount);
     } else {
         moduleSpinlockRelease();
         LOG_F("No free tracking slots for module %s (all %u slots in use). "

--- a/linux/trace.c
+++ b/linux/trace.c
@@ -58,6 +58,7 @@
 #include "linux/unwind.h"
 #include "report.h"
 #include "sanitizers.h"
+#include "hfuzz_metrics.h"
 #include "socketfuzzer.h"
 #include "subproc.h"
 
@@ -787,6 +788,9 @@ static void arch_traceSaveData(run_t* run, pid_t pid) {
 
     /* Increase global crashes counter */
     ATOMIC_POST_INC(run->global->cnts.crashesCnt);
+
+    /* Log crash metrics (optional - weak symbol, no-op if not overridden) */
+    hfuzz_metrics_log_crash(description, run->backtrace, run->dynfile->size);
 
     /*
      * Check if backtrace contains allowlisted symbol. Whitelist overrides

--- a/subproc.c
+++ b/subproc.c
@@ -44,6 +44,7 @@
 #include "libhfcommon/files.h"
 #include "libhfcommon/log.h"
 #include "libhfcommon/util.h"
+#include "hfuzz_metrics.h"
 
 extern char** environ;
 
@@ -540,6 +541,34 @@ void subproc_checkTimeLimit(run_t* run) {
             kill(run->pid, SIGKILL);
         }
         ATOMIC_POST_INC(run->global->cnts.timeoutedCnt);
+
+        /* Log hang metrics (optional - weak symbol, no-op if not overridden) */
+        hfuzz_metrics_log_hang(run->dynfile->size, 
+                                (uint64_t)(run->global->timing.tmOut * 1000));
+
+        /* Save the timeout input as a bug artifact */
+        if (run->dynfile && run->dynfile->data && run->dynfile->size > 0) {
+            char timeoutFileName[PATH_MAX];
+            uint64_t inputHash = util_hash((const char*)run->dynfile->data, run->dynfile->size);
+            
+            /* Use unique filename: TIMEOUT.SIZE.HASH.fuzz */
+            snprintf(timeoutFileName, sizeof(timeoutFileName),
+                "%s/TIMEOUT.%zu.%" PRIx64 ".%s",
+                run->global->io.crashDir, run->dynfile->size, inputHash,
+                run->global->io.fileExtn);
+            
+            /* Only save if file doesn't already exist (deduplication by hash) */
+            if (!files_exists(timeoutFileName)) {
+                if (files_writeBufToFile(timeoutFileName, run->dynfile->data, run->dynfile->size,
+                        O_CREAT | O_EXCL | O_WRONLY)) {
+                    LOG_I("Timeout: saved as '%s'", timeoutFileName);
+                } else {
+                    LOG_W("Couldn't save timeout input to '%s'", timeoutFileName);
+                }
+            } else {
+                LOG_D("Timeout (dup): '%s' already exists, skipping", timeoutFileName);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
record timeouts as bugs, much like libfuzzer does
metrics hooks, weak symbols allow us to load in the solfuzz metrics logger to capture coverage / stats to ClickHouse