### PR TITLE
LLVMFuzzerInitialize shadows harness strong definitions

### DIFF
--- a/libhfuzz/persistent.c
+++ b/libhfuzz/persistent.c
@@ -23,10 +23,7 @@
 #include "libhfuzz/libhfuzz.h"
 #include "libhfuzz/performance.h"
 
-__attribute__((weak)) int LLVMFuzzerInitialize(
-    int* argc HF_ATTR_UNUSED, char*** argv HF_ATTR_UNUSED) {
-    return 1;
-}
+__attribute__((weak)) int LLVMFuzzerInitialize(int* argc, char*** argv);
 
 /* Simple xorshift32 PRNG for in-process mutation */
 static uint32_t hf_rng_state = 0;
@@ -393,7 +390,9 @@ static int HonggfuzzRunFromFile(int argc, char** argv) {
 }
 
 int HonggfuzzMain(int argc, char** argv) {
-    LLVMFuzzerInitialize(&argc, &argv);
+    if (LLVMFuzzerInitialize) {
+        LLVMFuzzerInitialize(&argc, &argv);
+    }
     instrumentClearNewCov();
 
     if (!fetchIsInputAvailable()) {


### PR DESCRIPTION
The weak definition (no-op stub returning 1) was linked via `--whole-archive` and `--allow-multiple-definition`, causing it to shadow the harness's strong `LLVMFuzzerInitialize` that calls `register_descriptor()`. This meant protobuf-kutator mutation was silently no-op for all Cargo-built fuzz targets.