### PR TITLE
hfuzz-cc: disable only minimal wrapped builtins, not every builtin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ libs
 obj
 examples/badcode/targets/badcode1
 examples/badcode/targets/badcode2
+hfuzz_cc/nobuiltin_funcs.h

--- a/Makefile
+++ b/Makefile
@@ -249,6 +249,7 @@ SRCS := $(COMMON_SRCS) $(ARCH_SRCS)
 OBJS := $(SRCS:.c=.o)
 
 GIT_BUILDINFO_H := git_buildinfo.h
+NOBUILTIN_H := hfuzz_cc/nobuiltin_funcs.h
 
 LHFUZZ_SRCS := $(sort $(wildcard libhfuzz/*.c))
 LHFUZZ_OBJS := $(LHFUZZ_SRCS:.c=.o)
@@ -331,9 +332,9 @@ CLEAN_TARGETS := core Makefile.bak \
   $(LCOMMON_ARCH) $(LCOMMON_OBJS) \
   $(LNETDRIVER_ARCH) $(LNETDRIVER_OBJS) \
   $(MAC_GARGBAGE) $(ANDROID_GARBAGE) $(SUBDIR_GARBAGE) \
-  $(GIT_BUILDINFO_H)
+  $(GIT_BUILDINFO_H) $(NOBUILTIN_H)
 
-all: $(GIT_BUILDINFO_H) $(BIN) $(HFUZZ_CC_BIN) $(LHFUZZ_ARCH) $(LHFUZZ_SHARED) $(LCOMMON_ARCH) $(LNETDRIVER_ARCH)
+all: $(GIT_BUILDINFO_H) $(NOBUILTIN_H) $(BIN) $(HFUZZ_CC_BIN) $(LHFUZZ_ARCH) $(LHFUZZ_SHARED) $(LCOMMON_ARCH) $(LNETDRIVER_ARCH)
 
 # Generate git build info header with commit hash, author, and title
 .PHONY: $(GIT_BUILDINFO_H)
@@ -353,6 +354,25 @@ $(GIT_BUILDINFO_H):
 	 echo "#define GIT_COMMIT_TITLE \"$$GIT_TITLE\"" >> $@
 	@echo "" >> $@
 	@echo "#endif /* GIT_BUILDINFO_H */" >> $@
+
+# Derive the -fno-builtin-<fn> list from the functions libhfuzz/memorycmp.c
+# actually wraps, so adding a wrapper there cannot silently leave the compiler
+# free to inline it (see commonPreOpts in hfuzz_cc/hfuzz-cc.c).
+.PHONY: $(NOBUILTIN_H)
+$(NOBUILTIN_H): libhfuzz/memorycmp.c
+	@echo "Generating $@..."
+	@echo "/* Auto-generated from libhfuzz/memorycmp.c at build time - do not edit */" > $@
+	@echo "#ifndef HF_NOBUILTIN_FUNCS_H" >> $@
+	@echo "#define HF_NOBUILTIN_FUNCS_H" >> $@
+	@echo "" >> $@
+	@echo "#define HF_NOBUILTIN_FLAGS \\" >> $@
+	@tr '\n' ' ' < libhfuzz/memorycmp.c \
+	  | grep -oE 'HF_WEAK_WRAP\([^,]+,[[:space:]]*[A-Za-z_][A-Za-z_0-9]*' \
+	  | sed -E 's/.*,[[:space:]]*//' | grep -v '^func$$' | sort -u \
+	  | sed -E 's/.*/    "-fno-builtin-&", \\/' >> $@
+	@echo "    /* end */" >> $@
+	@echo "" >> $@
+	@echo "#endif /* HF_NOBUILTIN_FUNCS_H */" >> $@
 
 # honggfuzz.o depends on the git build info header
 honggfuzz.o: honggfuzz.c $(GIT_BUILDINFO_H)
@@ -381,7 +401,7 @@ mac/arch.o: mac/arch.c mac/mach_exc.h mac/mach_excServer.h
 $(BIN): $(OBJS) $(LCOMMON_ARCH) $(METRICS_OBJS)
 	$(LD) -o $(BIN) $(OBJS) $(METRICS_OBJS) $(LCOMMON_ARCH) $(LDFLAGS) $(HONGGFUZZ_LDFLAGS)
 
-$(HFUZZ_CC_BIN): $(LCOMMON_ARCH) $(LHFUZZ_ARCH) $(LNETDRIVER_ARCH) $(HFUZZ_CC_SRCS)
+$(HFUZZ_CC_BIN): $(LCOMMON_ARCH) $(LHFUZZ_ARCH) $(LNETDRIVER_ARCH) $(HFUZZ_CC_SRCS) $(NOBUILTIN_H)
 	$(LD) -o $@ $(HFUZZ_CC_SRCS) $(LCOMMON_ARCH) $(LDFLAGS) $(CFLAGS) $(CFLAGS_BLOCKS) -D_HFUZZ_INC_PATH=$(HFUZZ_INC)
 
 $(LCOMMON_OBJS): $(LCOMMON_SRCS)

--- a/hfuzz_cc/hfuzz-cc.c
+++ b/hfuzz_cc/hfuzz-cc.c
@@ -18,7 +18,16 @@
 #include "libhfcommon/log.h"
 #include "libhfcommon/util.h"
 
+#include "hfuzz_cc/nobuiltin_funcs.h"
+
 #define ARGS_MAX 4096
+/*
+ * Headroom reserved in args[] for the flags this wrapper injects on top of the
+ * caller's argv. The worst case is the linker path: commonPreOpts (including
+ * one -fno-builtin-<fn> per wrapped function, see wrappedFuncs) plus ldMode's
+ * own additions. Keep this comfortably above that total.
+ */
+#define ARGS_INJECTED_MAX 512
 
 static bool isCXX                     = false;
 static bool isGCC                     = false;
@@ -406,6 +415,13 @@ static char* getLibHFCommonPath() {
     return path;
 }
 
+/*
+ * The functions libhfuzz/memorycmp.c wraps, as -fno-builtin-<fn> flags.
+ * Generated from memorycmp.c at build time, so a wrapper added there is
+ * covered automatically and the two cannot drift apart.
+ */
+static char* const wrappedFuncs[] = {HF_NOBUILTIN_FLAGS};
+
 static void commonPreOpts(int* j, char** args) {
     args[(*j)++] = getIncPaths();
 
@@ -424,7 +440,27 @@ static void commonPreOpts(int* j, char** args) {
         args[(*j)++] = "-inline-threshold=1000";
     }
 
-    args[(*j)++] = "-fno-builtin";
+    /*
+     * Keep the functions libhfuzz/memorycmp.c wraps out of the compiler's
+     * hands, so a call reaches the wrapper instead of being inlined or
+     * constant-folded and losing its instrumentUpdateCmpMap feedback.
+     *
+     * This used to be a blanket -fno-builtin, which also disabled the math
+     * builtins. That has a consequence well beyond coverage: with pow() opaque,
+     * the compiler stops contracting floating-point expressions it would
+     * otherwise fuse, so an instrumented build computes different FP results
+     * than the same source built normally. Anyone diffing an instrumented
+     * target against a reference implementation is then comparing a binary
+     * that does not match the one they ship -- firedancer #10553 was a 1-ulp
+     * consensus divergence that was invisible to differential fuzzing for that
+     * exact reason. Disable the wrapped functions by name instead.
+     *
+     * Names the compiler does not recognize are accepted and ignored, so the
+     * list can mirror memorycmp.c exactly.
+     */
+    for (size_t i = 0; i < ARRAYSIZE(wrappedFuncs); i++) {
+        args[(*j)++] = wrappedFuncs[i];
+    }
     args[(*j)++] = "-fno-omit-frame-pointer";
     args[(*j)++] = "-D__NO_STRING_INLINES";
 
@@ -688,7 +724,7 @@ int main(int argc, char** argv) {
         return execCC(argc, argv);
     }
 
-    if (argc > (ARGS_MAX - 128)) {
+    if (argc > (ARGS_MAX - ARGS_INJECTED_MAX)) {
         LOG_F("'%s': Too many positional arguments: %d", argv[0], argc);
         return EXIT_FAILURE;
     }


### PR DESCRIPTION
The overzealous `-fno-builtin` compiler option added by Honggfuzz's compiler wrapper is only needed for the functions memorycmp.c instruments for fuzzing diversity feedback signal, but it also unexpectedly disables the math builtins, which disables FMA contraction and leaves instrumented targets computing different results than the shipped binary. That concealed floating point math mismatches with Agave for over a year.
