### PR TITLE
perf: skip untouched words in the 8-bit counter sweep

### DIFF
--- a/libhfuzz/instrument.c
+++ b/libhfuzz/instrument.c
@@ -1108,6 +1108,24 @@ void instrument8BitCountersCount(void) {
 
     for (size_t i = 0; i < ARRAYSIZE(hf8bitcounters) && hf8bitcounters[i].start; i++) {
         for (size_t j = 0; j < hf8bitcounters[i].cnt; j++) {
+            /* Fast-skip whole words of untouched counters.
+             *
+             * The loop below reads and unconditionally zeroes every counter in
+             * the region.  For a target registering millions of counters that
+             * dirties every cache line of a multi-MB array on every iteration,
+             * even though the overwhelming majority of counters are zero.
+             *
+             * Peek at 8 counters at a time and skip the group when none of them
+             * were touched, leaving those lines clean.  Behaviour is unchanged:
+             * every non-zero counter is still accounted for and cleared below. */
+            if ((j & 7U) == 0U && j + sizeof(uint64_t) <= hf8bitcounters[i].cnt) {
+                uint64_t word;
+                memcpy(&word, (const void*)&hf8bitcounters[i].start[j], sizeof(word));
+                if (!word) {
+                    j += sizeof(uint64_t) - 1U;
+                    continue;
+                }
+            }
             const uint8_t v            = hf8bitcounters[i].start[j];
             hf8bitcounters[i].start[j] = 0;
             if (!v) {


### PR DESCRIPTION
## Problem

`instrument8BitCountersCount()` runs once per fuzz iteration and walks **every** registered counter, reading each byte and unconditionally storing zero back:

```c
for (size_t j = 0; j < hf8bitcounters[i].cnt; j++) {
    const uint8_t v            = hf8bitcounters[i].start[j];
    hf8bitcounters[i].start[j] = 0;   // stores even when already zero
    if (!v) continue;
    ...
}
```

On the solfuzz differential harness the agave target registers **2,555,211** counters. That unconditional store dirties every cache line of a ~2.5 MB array on every iteration, even though almost all counters are zero for any given input. The cost is the write-back traffic, not the scan.

## Change

Peek at 8 counters at a time and skip the group when none were touched, leaving untouched lines clean. Semantics are unchanged — every non-zero counter is still accounted for and cleared by the existing code path.

18 added lines, one file.

## Measurements

solfuzz differential harness (agave + firedancer targets, 16 threads, AMD EPYC 9474F, 120 s runs, 3 reps):

| harness | before | after | delta |
|---|---|---|---|
| syscall | 6,532 exec/s | **10,150 exec/s** | **+55.4%** |
| instr | 1,932 exec/s | **2,357 exec/s** | **+22.0%** |

Profile (`perf`, corroborated with IBS `ibs_op`):

| | before | after |
|---|---|---|
| `instrument8BitCountersCount` share of cycles | **33.06%** | **7.42%** |
| instructions per run | 46.65 G | 23.75 G (−49%) |

syscall gains more than instr because it runs ~4x more inputs per second, so it pays the per-iteration sweep proportionally more often.

## Coverage is unaffected

| harness | edges before | edges after | new units |
|---|---|---|---|
| syscall | 3,610 | 3,607 | 350 → 374 |
| instr | 18,307 | 18,206 | 5,467 → 5,685 |

Both edge deltas are inside run-to-run variance (per-arm cv ≤ 1.3%), and corpus discovery is slightly up. Also checked with 45-minute runs, arm order reversed between pairs, on two independent harnesses.

## Testing

- `make libhfuzz/libhfuzz.a` and `make honggfuzz` build clean (`-Wall -Wextra -Werror`)
- Change only affects the 8-bit-counter feedback path; targets using `trace-pc-guard` are untouched
- Validated end to end through solfuzz `fuzz_syscall` / `fuzz_instr` against firedancer + solfuzz-agave `.so`s

🤖 Generated with [Claude Code](https://claude.com/claude-code)