### PR TITLE
perf: widen the counter-sweep skip from 8 to 32 bytes

### DIFF
--- a/libhfuzz/instrument.c
+++ b/libhfuzz/instrument.c
@@ -1115,14 +1115,17 @@ void instrument8BitCountersCount(void) {
              * dirties every cache line of a multi-MB array on every iteration,
              * even though the overwhelming majority of counters are zero.
              *
-             * Peek at 8 counters at a time and skip the group when none of them
+             * Peek at 32 counters at a time and skip the group when none of them
              * were touched, leaving those lines clean.  Behaviour is unchanged:
              * every non-zero counter is still accounted for and cleared below. */
-            if ((j & 7U) == 0U && j + sizeof(uint64_t) <= hf8bitcounters[i].cnt) {
-                uint64_t word;
-                memcpy(&word, (const void*)&hf8bitcounters[i].start[j], sizeof(word));
-                if (!word) {
-                    j += sizeof(uint64_t) - 1U;
+            if ((j & 31U) == 0U && j + 32U <= hf8bitcounters[i].cnt) {
+                uint64_t w0, w1, w2, w3;
+                memcpy(&w0, (const void*)&hf8bitcounters[i].start[j + 0U], sizeof(w0));
+                memcpy(&w1, (const void*)&hf8bitcounters[i].start[j + 8U], sizeof(w1));
+                memcpy(&w2, (const void*)&hf8bitcounters[i].start[j + 16U], sizeof(w2));
+                memcpy(&w3, (const void*)&hf8bitcounters[i].start[j + 24U], sizeof(w3));
+                if (!(w0 | w1 | w2 | w3)) {
+                    j += 31U;
                     continue;
                 }
             }


### PR DESCRIPTION
Follow-up to #39. That change skips 8 counters at a time; this widens the emptiness test to 32 (four `uint64_t` loads OR'd together), cutting the loop/branch overhead 4x on the common all-zero path.

## Measurements

Same harness as #39 (solfuzz differential, agave + firedancer targets, 2,555,211 registered counters, 16 threads, AMD EPYC 9474F, 120 s runs, 3 reps):

| harness | #39 (8-byte) | this PR (32-byte) | delta |
|---|---|---|---|
| syscall | 10,150 exec/s | **10,599 exec/s** | **+4.4%** |
| instr | 2,357 exec/s | **2,465 exec/s** | **+4.6%** |

Coverage unchanged: syscall edges 3,607 → 3,610, instr edges 18,206 → 18,453.

Cumulative with #39, against the pre-#39 sweep: syscall **+62%**, instr **+28%**.

## Why scalar and not AVX-512

This was measured, not assumed. Scan-only microbenchmark, µs per 2,555,211-counter region, built with the project's own `-O3 -mtune=native -funroll-loops`:

| non-zero density | byte | 8B (#39) | **32B (this PR)** | 64B AVX-512 |
|---|---|---|---|---|
| 0.020% | 849 | 351 | **84** | 73 |
| 0.078% | 875 | 389 | **133** | 146 |
| 0.391% | 1007 | 588 | **388** | 513 |
| 1.957% | 1673 | 1561 | **1526** | 1730 |

AVX-512 only wins at the very sparsest density, and at ~2% density it is slower than the original byte loop. The cause is fallback granularity: when a block contains any non-zero counter the entire block must still be walked byte-by-byte, so a wider block wastes proportionally more work on every hit. 32 bytes is the sweet spot across the realistic range.

It would also need `-march=native` or a `target` attribute; the project's `CFLAGS` are `-mtune=native` only, so no vector code is emitted today. The scalar version needs no ISA flags, no runtime dispatch, and no portability caveats.

## Scope caveat (same as #39)

This only helps targets that actually register 8-bit counters. On stock solfuzz-agave, agave is built with `trace-pc-guard` and registers **zero** counters (only firedancer registers 34,531), and the patch measures **−1.3%, i.e. nothing**. The gains above require agave to be on `inline-8bit-counters` so 2,555,211 counters go through the sweep.

## Testing

`make libhfuzz/libhfuzz.a` and `make honggfuzz` build clean under `-Wall -Wextra -Werror`. Validated end to end through solfuzz `fuzz_syscall` / `fuzz_instr` against firedancer + solfuzz-agave `.so`s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)